### PR TITLE
WinSW instead of NSSM

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -73,6 +73,7 @@ Set "BinDir=%CurDir%\buildenv\bin"
 Set "CnfDir=%CurDir%\buildenv\conf"
 Set "InsDir=%CurDir%\installer"
 Set "PreDir=%CurDir%\prereqs"
+Set "SrvConfDir=%CurDir%\winsw"
 for /f "delims=" %%a in ('git rev-parse --show-toplevel') do @set "SrcDir=%%a"
 
 :: Find the NSIS Installer
@@ -107,27 +108,27 @@ xcopy /E /Q "%PyDir%" "%BinDir%\"
 :: Copy the default master and minion configs to buildenv\conf
 @echo Copying configs to buildenv\conf...
 @echo ----------------------------------------------------------------------
-@echo xcopy /E /Q "%SrcDir%\conf\master" "%CnfDir%\"
+@echo xcopy /Q /Y "%SrcDir%\conf\master" "%CnfDir%\"
 xcopy /Q /Y "%SrcDir%\conf\master" "%CnfDir%\"
-@echo xcopy /E /Q "%SrcDir%\conf\minion" "%CnfDir%\"
+@echo xcopy /Q /Y "%SrcDir%\conf\minion" "%CnfDir%\"
 xcopy /Q /Y "%SrcDir%\conf\minion" "%CnfDir%\"
 @echo.
 
-@echo Copying NSSM to buildenv
+@echo Copying WinSW to buildenv
 @echo ----------------------------------------------------------------------
 :: Make sure the "prereq" directory exists
 If NOT Exist "%PreDir%" mkdir "%PreDir%"
 
-:: Set the location of the ssm to download
-Set Url64="https://repo.saltstack.com/windows/dependencies/64/ssm-2.24-103-gdee49fc.exe"
-Set Url32="https://repo.saltstack.com/windows/dependencies/32/ssm-2.24-103-gdee49fc.exe"
+:: Set the location of the winSW to download
+Set "Url=https://github.com/kohsuke/winsw/releases/download/winsw-v2.1.2/WinSW.NET4.exe"
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url%" -file "%BldDir%\salt-minion.exe"
 
-:: Check for 64 bit by finding the Program Files (x86) directory
-If Defined ProgramFiles(x86) (
-    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url64%" -file "%BinDir%\ssm.exe"
-) Else (
-    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url32%" -file "%BinDir%\ssm.exe"
-)
+@echo xcopy /Q /Y "%SrvConfDir%\salt-minion.xml" "%CnfDir%\"
+xcopy /Q /Y "%SrvConfDir%\salt-minion.xml" "%BldDir%\"
+
+@echo xcopy /Q /Y "%SrvConfDir%\salt-minion.exe.config" "%CnfDir%\"
+xcopy /Q /Y "%SrvConfDir%\salt-minion.exe.config" "%BldDir%\"
+
 @echo.
 
 @echo Copying VCRedist to Prerequisites

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -658,11 +658,7 @@ Section -Post
     WriteRegStr HKLM "${PRODUCT_MINION_REGKEY}" "Path" "$INSTDIR\bin\"
 
     # Register the Salt-Minion Service
-    nsExec::Exec "$INSTDIR\bin\ssm.exe install salt-minion $INSTDIR\bin\python.exe -E -s $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
-    nsExec::Exec "$INSTDIR\bin\ssm.exe set salt-minion Description Salt Minion from saltstack.com"
-    nsExec::Exec "$INSTDIR\bin\ssm.exe set salt-minion Start SERVICE_AUTO_START"
-    nsExec::Exec "$INSTDIR\bin\ssm.exe set salt-minion AppStopMethodConsole 24000"
-    nsExec::Exec "$INSTDIR\bin\ssm.exe set salt-minion AppStopMethodWindow 2000"
+    nsExec::Exec "salt-minion.exe install"
 
     ${IfNot} $ConfigType_State == "Existing Config"  # If not using Existing Config
         Call updateMinionConfig
@@ -680,7 +676,7 @@ Function .onInstSuccess
 
     # If StartMinionDelayed is 1, then set the service to start delayed
     ${If} $StartMinionDelayed == 1
-        nsExec::Exec "$INSTDIR\bin\ssm.exe set salt-minion Start SERVICE_DELAYED_AUTO_START"
+        nsExec::Exec "sc config salt-minion start= delayed-auto"
     ${EndIf}
 
     # If start-minion is 1, then start the service
@@ -740,7 +736,7 @@ Function ${un}uninstallSalt
 
     # Remove files
     Delete "$INSTDIR\uninst.exe"
-    Delete "$INSTDIR\nssm.exe"
+    Delete "$INSTDIR\salt-minion.exe"
     Delete "$INSTDIR\salt*"
     Delete "$INSTDIR\vcredist.exe"
     RMDir /r "$INSTDIR\bin"

--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -38,11 +38,14 @@ Function DownloadFileWithProgress {
             -SourceIdentifier WebClient.DownloadProgressChanged `
             -Action { $Global:DPCEventArgs = $EventArgs }
         }
-}
+    }
+
     process {
         if ( $Global:NEED_PROCESS_AND_END ) {
             Write-Verbose " ++++++ actually DOWNLOADING ++++++ $localFile +++++++"
             Write-Progress -Activity 'Downloading file' -Status $url
+            # Support downloads from all TLS flavors
+            [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
             $client.DownloadFileAsync($url, $localFile)
 
             while (!($Global:downloadComplete)) {

--- a/pkg/windows/winsw/salt-minion.exe.config
+++ b/pkg/windows/winsw/salt-minion.exe.config
@@ -1,0 +1,5 @@
+<configuration>
+  <runtime>
+    <generatePublisherEvidence enabled="false"/> 
+  </runtime>
+</configuration>

--- a/pkg/windows/winsw/salt-minion.xml
+++ b/pkg/windows/winsw/salt-minion.xml
@@ -1,0 +1,10 @@
+<service>
+  <id>salt-minion</id>
+  <name>salt-minion</name>
+  <description>Salt Minion from saltstack.com</description>
+  <executable>%BASE%\bin\python.exe</executable>
+  <arguments>-E -s &quot;%BASE%\bin\Scripts\salt-minion&quot; -c &quot;%BASE%\conf&quot; -l quiet</arguments>
+  <stoptimeout>24sec</stoptimeout>
+  <onfailure action="restart" />
+  <workingdirectory>%BASE%</workingdirectory>
+</service>


### PR DESCRIPTION
Replace NSSM service wrapper by WinSW service wrapper in the Windows Salt Minion setup.

Signed-off-by: Alexander Fischer <afischer@opentext.com>

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
